### PR TITLE
Add branches to protect against destroyed instance

### DIFF
--- a/src/ScrollWatch.js
+++ b/src/ScrollWatch.js
@@ -188,9 +188,7 @@ var saveElements = function() {
 // perform comparison checks.
 var saveScrollPosition = function() {
 
-  if (instanceData[this._id]) {
-    instanceData[this._id].lastScrollPosition = getScrollPosition.call(this);
-  }
+  instanceData[this._id].lastScrollPosition = getScrollPosition.call(this);
 
 };
 
@@ -485,10 +483,6 @@ var getScrolledAxis = function() {
 
 var getScrolledDirection = function(axis) {
 
-  if (!instanceData[this._id]) {
-    return scrollDir[axis][0];
-  }
-
 	var scrollDir = {x: ['right', 'left'], y: ['down', 'up']};
 	var position = {x: 'left', y: 'top'};
 	var lastScrollPosition = instanceData[this._id].lastScrollPosition;
@@ -499,10 +493,6 @@ var getScrolledDirection = function(axis) {
 };
 
 var hasScrollPositionChanged = function(axis) {
-
-  if (!instanceData[this._id]) {
-    return false;
-  }
 
 	var position = {x: 'left', y: 'top'};
 	var lastScrollPosition = instanceData[this._id].lastScrollPosition;
@@ -547,6 +537,12 @@ var mergeOptions = function(opts) {
 };
 
 var handler = function(e) {
+
+  // protect against the instance being destroyed while we still
+  // have queued or pending handler events
+  if (!instanceData[this._id]) {
+    return
+  }
 
 	var eventType = e.type;
 

--- a/src/ScrollWatch.js
+++ b/src/ScrollWatch.js
@@ -188,7 +188,9 @@ var saveElements = function() {
 // perform comparison checks.
 var saveScrollPosition = function() {
 
-	instanceData[this._id].lastScrollPosition = getScrollPosition.call(this);
+  if (instanceData[this._id]) {
+    instanceData[this._id].lastScrollPosition = getScrollPosition.call(this);
+  }
 
 };
 
@@ -483,6 +485,10 @@ var getScrolledAxis = function() {
 
 var getScrolledDirection = function(axis) {
 
+  if (!instanceData[this._id]) {
+    return scrollDir[axis][0];
+  }
+
 	var scrollDir = {x: ['right', 'left'], y: ['down', 'up']};
 	var position = {x: 'left', y: 'top'};
 	var lastScrollPosition = instanceData[this._id].lastScrollPosition;
@@ -493,6 +499,10 @@ var getScrolledDirection = function(axis) {
 };
 
 var hasScrollPositionChanged = function(axis) {
+
+  if (!instanceData[this._id]) {
+    return false;
+  }
 
 	var position = {x: 'left', y: 'top'};
 	var lastScrollPosition = instanceData[this._id].lastScrollPosition;

--- a/src/ScrollWatch.js
+++ b/src/ScrollWatch.js
@@ -193,13 +193,19 @@ var saveScrollPosition = function() {
 };
 
 var checkViewport = function(eventType) {
+  // Check before each call if instanceData has been destroyed, in case the instace
+  // was destroyed from inside a handler
 
-	checkElements.call(this, eventType);
-	checkInfinite.call(this, eventType);
+  if (!instanceData[this._id]) return
+  checkElements.call(this, eventType);
+  
+  if (!instanceData[this._id]) return
+  checkInfinite.call(this, eventType);
 
 	// Chrome does not return 0,0 for scroll position when reloading a page
 	// that was previously scrolled. To combat this, we will leave the scroll
 	// position at the default 0,0 when a page is first loaded.
+  if (!instanceData[this._id]) return
 	if (eventType !== initEvent) {
 
 		saveScrollPosition.call(this);


### PR DESCRIPTION
Destroyed Scrollwatch instances result in a undefined error being thrown. This adds a guard to protect against that.